### PR TITLE
Added campaign monitor as an option

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+# Copy these to the main env
+CAMPAIGNMONITOR_CLIENT_ID = ''
+CAMPAIGNMONITOR_API_KEY = ''

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
 	"type": "silverstripe-vendormodule",
   "require": {
     "silverstripe/cms": "~4.0",
-    "silverstripe/framework": "~4.0"
+    "silverstripe/framework": "~4.0",
+    "campaignmonitor/createsend-php": "*"
   },
   "extra": {
     "expose": [

--- a/src/NewsletterPageExtender.php
+++ b/src/NewsletterPageExtender.php
@@ -1,5 +1,6 @@
 <?php
 /**/
+use SilverStripe\Core\Environment;
 use SilverStripe\SiteConfig\SiteConfig;
 use SilverStripe\Forms\EmailField;
 use SilverStripe\Forms\FieldList;
@@ -16,8 +17,6 @@ class NewsletterPageExtender extends DataExtension {
 	];
 	/**/
 	public function NewsletterForm(){
-
-		//
 		$config = SiteConfig::current_site_config();
 
 		if ($this->owner->isAjax) {
@@ -78,6 +77,17 @@ class NewsletterPageExtender extends DataExtension {
   /**/
   public function InsertToNewsletter($Email){
     $status = true;
+  	$config = SiteConfig::current_site_config();
+
+    if($config->NewsletterAPI=="campaignmonitor" && $config->CampaignMonitorListID){
+      $auth = array('api_key' => Environment::getEnv('CAMPAIGNMONITOR_API_KEY'));
+      $wrap = new CS_REST_Subscribers($config->CampaignMonitorListID, $auth);
+      $result = $wrap->add(array(
+        'EmailAddress' => $Email,
+        'ConsentToTrack' => 'yes',
+        'Resubscribe' => true
+      ));
+    }
 
     //SAVE SUBMISSION NO MATTER WHAT API (or if none)
     $submission = new NewsletterSubmission();

--- a/src/NewsletterSettings.php
+++ b/src/NewsletterSettings.php
@@ -1,5 +1,7 @@
 <?php
 /**/
+use SilverStripe\Core\Environment;
+use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\HTMLEditor\HTMLEditorField;
 use SilverStripe\Forms\OptionsetField;
@@ -9,29 +11,45 @@ use SilverStripe\ORM\DataExtension;
 class NewsletterSettings extends DataExtension {
 	/**/
 	private static $db = [
-		'NewsletterAPI' => "Enum('constantcontact,mailchimp,none', 'none')",
+		'NewsletterAPI' => "Enum('campaignmonitor,mailchimp,none', 'none')",
 		"NewsletterSuccessText" => "HTMLText",
 		"NewsletterErrorText" => "HTMLText",
 		'NewsletterFormButtonText' => "Text",
+
+    'CampaignMonitorListID' => "Text",
 	];
 	/**/
   public function updateCMSFields(FieldList $fields) {
-		/**/
+
 		$fields->findOrMakeTab('Root.Newsletter', 'Newsletter');
-		//PAGE LAYOUT
+
 		$fields->addFieldToTab(
 			"Root.Newsletter",
 			OptionsetField::create(
 				'NewsletterAPI',
 				'Select your newsletter API',
 				array(
-					/*'constantcontact' => 'Constant Contact',
-					'mailchimp' => 'Mail Chimp',*/
+					'campaignmonitor' => 'Campaign Monitor',
 					'none' => 'No API'
 				),
 				'none'
 			)
 		);
+
+    // Campaign Monitor
+    if(Environment::getEnv('CAMPAIGNMONITOR_API_KEY') && Environment::getEnv('CAMPAIGNMONITOR_CLIENT_ID')){
+      $auth = array('api_key' => Environment::getEnv('CAMPAIGNMONITOR_API_KEY'));
+      $wrap = new CS_REST_Clients(Environment::getEnv('CAMPAIGNMONITOR_CLIENT_ID'), $auth);
+      $result = $wrap->get_lists();
+      //echo "<pre>";print_r($result);die();
+			$listarray = array();
+      foreach($result->response as $list){
+        $listarray[$list->ListID] = $list->Name;
+      }
+      $CampaignMonitorListID = DropdownField::create("CampaignMonitorListID", "Select a list", $listarray)
+        ->displayIf("NewsletterAPI")->isEqualTo("campaignmonitor")->end();
+  		$fields->addFieldToTab('Root.Newsletter', $CampaignMonitorListID);
+    }
 
 		//BUTTON TEXT
 		$fields->addFieldToTab("Root.Newsletter", TextField::create("NewsletterFormButtonText", "Button Text"));


### PR DESCRIPTION
- required an api key and client id (I was using our werkbot account for testing)
- list can be specified to save the emails too

The original card: https://trello.com/c/N8a0xGdl/63-setup-campaign-monitor-account