### PR TITLE
Removed comma causing a syntax error

### DIFF
--- a/src/NewsletterPageExtender.php
+++ b/src/NewsletterPageExtender.php
@@ -29,7 +29,7 @@ class NewsletterPageExtender extends DataExtension {
     );
 
     $NewsletterTab->push(new Tab('NewsletterTab', 'Newsletter Options',
-      $NewsletterShowHide,
+      $NewsletterShowHide
     ));
   }
 }


### PR DESCRIPTION
https://werkbotstudios.teamwork.com/#/tasks/23781764

### Summary
Removed a comma that causes a syntax error

### Testing
- [x] This would happen with my xampp sites, running php 7.1, perhaps this is not an issue for other versions. Confirm no error shows. This would happen on any page

### Concern
Probably worth a patch release.