### PR TITLE
fix: check for name variables in request array

### DIFF
--- a/src/NewsletterPageControllerExtender.php
+++ b/src/NewsletterPageControllerExtender.php
@@ -93,8 +93,11 @@ class NewsletterPageControllerExtender extends DataExtension
    */
   public function ProcessNewsletterForm($data, Form $form)
   {
+    $email = isset($data["Email"]) ? $data["Email"] : "";
+    $firstname = isset($data["FirstName"]) ? $data["FirstName"] : "";
+    $lastname = isset($data["LastName"]) ? $data["LastName"] : "";
 
-    $status = $this->owner->InsertToNewsletter($data["Email"], $data["FirstName"], $data["LastName"]);
+    $status = $this->owner->InsertToNewsletter($email, $firstname, $lastname);
 
     $resultdata = [
       "NewsletterMessage" => "",


### PR DESCRIPTION
https://werkbotstudios.teamwork.com/app/tasks/32907497

### Summary
Adds checks and default values for newsletter data

### Testing Steps
- [x] confirm the newsletter form behaves normally

### Issues/Concerns
- I was unable to reproduce this in my own browser, but the sentry task shows the original body. There is no First or Last name there. The name fields are hidden, so they are supposed to show in the request as empty strings, but perhaps the user's browser removes these when it submits the form (if it is a normal user, the email in the body looks generated).

### Git Flow
- **DO NOT** delete "release/\*" or "hotfix/\*" branches after merging a PR. These are used to publish the next release, and they are deleted automatically.
- "Squash and merge" is good on "feature/\*" into "develop"
- "Create a merge commit" is good on "release/\*" or "hotfix/\*" into "master"
